### PR TITLE
qtr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,22 +1,24 @@
 Package: phimethods
 Title: Standard Methods for use in PHI
 Version: 0.0.0.9000
-Authors@R: 
-    person("Jack",
-           "Hannah",
-           role = c("aut", "cre"),
-           email = "jack.hannah1@nhs.net")
+Authors@R: c(
+    person("Jack", "Hannah", email = "jack.hannah1@nhs.net", role = c("aut", "cre")),
+    person("Tina", "Fu", email = "tina.fu@nhs.net", role = "aut"),
+    person("Ciara", "Gribben", email = "ciaragribben@nhs.net", role = "aut")
+    )
 Description: Bespoke functions for commonly undertaken tasks by analysts in PHI.
+License: GPL (>= 2)
+URL: https://github.com/Health-SocialCare-Scotland/phimethods
+BugReports: https://github.com/Health-SocialCare-Scotland/phimethods/issues
 Imports:
     dplyr,
     glue,
     lubridate,
     stringi,
     stringr
-License: GPL (>= 2)
-Encoding: UTF-8
-LazyData: true
 Suggests: 
     covr,
     testthat
+Encoding: UTF-8
+LazyData: true
 RoxygenNote: 6.1.1

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -37,7 +37,7 @@ qtr_year <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (class(date) != "Date") {
-    stop("The current input is not a date. It must be in date format")
+    stop("The input must have Date class")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -72,7 +72,7 @@ qtr_end <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (class(date) != "Date") {
-    stop("The date must be provided in standard date format YYYY-MM-DD")
+    stop("The input must have Date class")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -107,7 +107,7 @@ qtr_prev <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (class(date) != "Date") {
-    stop("The date must be provided in standard date format YYYY-MM-DD")
+    stop("The input must have Date class")
   }
 
   quarter_num <- lubridate::quarter(date)


### PR DESCRIPTION
Hi Tina,

This is a small PR mainly to edit the error messages in the `qtr` functions if the input is something other than a date. Using the word 'format' is possibly a little ambiguous, as variables which are of the right format but the wrong class (such as a `character` variable with the format `YYYY-MM-DD`) won't work. I'm happy to be flexible on the exact phrasing, as long as the word "class" is in there and it's the same as the equivalent error message in @ciarag01's `fin_year` function.

I also added you and Ciara as authors in the description file.

Thanks!
